### PR TITLE
Added a `ToKeys` method to return array of keys instead of formatting

### DIFF
--- a/HotKeys2.Test/HotKeyEntryTest.cs
+++ b/HotKeys2.Test/HotKeyEntryTest.cs
@@ -35,4 +35,24 @@ public class HotKeyEntryTest
         var u = new HotKeyEntryByCode(null!, ModCode.None, Code.U, _ => ValueTask.CompletedTask, null, new() { Description = "Increment counter." });
         u.ToString().Is("U: Increment counter.");
     }
+
+    [Test]
+    public void ToKeys_for_ByCode_Test()
+    {
+        var ctrl_alt_f12 = new HotKeyEntryByCode(null!, ModCode.Ctrl | ModCode.Alt, Code.F12, _ => ValueTask.CompletedTask, null, new() { Description = "Set the volume level to 10." });
+        ctrl_alt_f12.ToKeys().IsStructuralEqual(new[] { "Ctrl", "Alt", "F12" });
+
+        var meta_one = new HotKeyEntryByCode(null!, ModCode.Meta, Code.Num1, _ => ValueTask.CompletedTask, null, new() { Description = "Launch the notepad." });
+        meta_one.ToKeys().IsStructuralEqual(new[] { "Meta", "1" });
+
+        var u = new HotKeyEntryByCode(null!, ModCode.None, Code.U, _ => ValueTask.CompletedTask, null, new() { Description = "Increment counter." });
+        u.ToKeys().IsStructuralEqual(new[] { "U" });
+    }
+
+    [Test]
+    public void ToKeys_for_ByKey_Test()
+    {
+        var hotKeyEntry = new HotKeyEntryByKey(null!, ModKey.None, Key.Question, _ => ValueTask.CompletedTask, null, new() { Description = "Show help." });
+        hotKeyEntry.ToKeys().IsStructuralEqual(new[] { "?" });
+    }
 }

--- a/HotKeys2/HotKeyEntry.cs
+++ b/HotKeys2/HotKeyEntry.cs
@@ -116,6 +116,15 @@ public abstract class HotKeyEntry : IDisposable
     /// <param name="format">{0} will be replaced with key combination text, and {1} will be replaced with description of this hotkey entry object.</param>
     public string ToString(string format)
     {
+        var keyComboText = string.Join(" + ", this.ToKeys());
+        return string.Format(format, keyComboText, this.Description);
+    }
+
+    /// <summary>
+    /// Returns an array of String formatted keys.
+    /// </summary>
+    public string[] ToKeys()
+    {
         var keyCombo = new List<string>();
         if (this._Modifiers != 0)
         {
@@ -133,8 +142,7 @@ public abstract class HotKeyEntry : IDisposable
             this._KeyEntry;
         keyCombo.Add(keyDisplayName);
 
-        var keyComboText = string.Join(" + ", keyCombo);
-        return string.Format(format, keyComboText, this.Description);
+        return keyCombo.ToArray();
     }
 
     public void Dispose()


### PR DESCRIPTION
Added a helper method `HotKeyEntry`.`ToKeys` to return array of formatted keys like in `ToString`.
This is useful if one want's to display something like this:
`Ctrl` + `Shift` + `A`
Note that each element can be a separate HTML tag (like `<span>` or anything else).
Using `ToString` would require extracting text manually.

Also added a simple test for new method and retained backward compatibility for `ToString` (it uses `ToKeys` now).