### PR TITLE
Fix: silence TaskCanceledException / OperationCanceledException on Blazor Server circuit disconnect

### DIFF
--- a/HotKeys2/Extensions/JS.cs
+++ b/HotKeys2/Extensions/JS.cs
@@ -54,7 +54,7 @@ internal static class JS
         try { await action(); }
         catch (JSDisconnectedException) { }
         catch (OperationCanceledException) { }
-        catch (AggregateException ex) when (ex.InnerExceptions.All(e => e is OperationCanceledException or AggregateException { InnerException: OperationCanceledException })) { }
+        catch (AggregateException ex) when (ex.Flatten().InnerExceptions.All(e => e is OperationCanceledException)) { }
         catch (Exception ex) { logger.LogError(ex, ex.Message); }
     }
 }

--- a/HotKeys2/Extensions/JS.cs
+++ b/HotKeys2/Extensions/JS.cs
@@ -52,7 +52,9 @@ internal static class JS
     public static async ValueTask InvokeSafeAsync(Func<ValueTask> action, ILogger logger)
     {
         try { await action(); }
-        catch (JSDisconnectedException) { } // Ignore this exception because it is thrown when the user navigates to another page.
+        catch (JSDisconnectedException) { }
+        catch (OperationCanceledException) { }
+        catch (AggregateException ex) when (ex.InnerExceptions.All(e => e is OperationCanceledException or AggregateException { InnerException: OperationCanceledException })) { }
         catch (Exception ex) { logger.LogError(ex, ex.Message); }
     }
 }

--- a/HotKeys2/Extensions/SemaphoreSlimExtensions.cs
+++ b/HotKeys2/Extensions/SemaphoreSlimExtensions.cs
@@ -9,7 +9,7 @@ internal static class SemaphoreSlimExtensions
         await semaphore.WaitAsync();
         try { return await asyncAction.Invoke(); }
         catch (OperationCanceledException) { return default!; }
-        catch (AggregateException ex) when (ex.InnerExceptions.All(e => e is OperationCanceledException or AggregateException { InnerException: OperationCanceledException })) { return default!; }
+        catch (AggregateException ex) when (ex.Flatten().InnerExceptions.All(e => e is OperationCanceledException)) { return default!; }
         catch (Exception ex)
         {
             if (logger != null)

--- a/HotKeys2/Extensions/SemaphoreSlimExtensions.cs
+++ b/HotKeys2/Extensions/SemaphoreSlimExtensions.cs
@@ -8,6 +8,8 @@ internal static class SemaphoreSlimExtensions
     {
         await semaphore.WaitAsync();
         try { return await asyncAction.Invoke(); }
+        catch (OperationCanceledException) { return default!; }
+        catch (AggregateException ex) when (ex.InnerExceptions.All(e => e is OperationCanceledException or AggregateException { InnerException: OperationCanceledException })) { return default!; }
         catch (Exception ex)
         {
             if (logger != null)

--- a/HotKeys2/HotKeysContext.cs
+++ b/HotKeys2/HotKeysContext.cs
@@ -634,6 +634,7 @@ public partial class HotKeysContext : IDisposable, IAsyncDisposable
             await JS.InvokeSafeAsync(async () =>
             {
                 var context = await this._JSContextTask;
+                if (context is null) return;
                 hotKeyEntry.Id = await context.InvokeAsync<int>(
                     "register",
                     hotKeyEntry._ObjectRef, hotKeyEntry.Mode, hotKeyEntry._Modifiers, hotKeyEntry._KeyEntry, hotKeyEntry.Exclude, hotKeyEntry.ExcludeSelector, hotKeyEntry.State);
@@ -653,6 +654,7 @@ public partial class HotKeysContext : IDisposable, IAsyncDisposable
             await JS.InvokeSafeAsync(async () =>
             {
                 var context = await this._JSContextTask;
+                if (context is null) return;
                 await context.InvokeVoidAsync("update", hotKeyEntry.Id, hotKeyEntry.State);
             }, this._Logger);
             return true;
@@ -664,6 +666,7 @@ public partial class HotKeysContext : IDisposable, IAsyncDisposable
         await JS.InvokeSafeAsync(async () =>
         {
             var context = await this._JSContextTask;
+            if (context is null) return;
             await context.InvokeVoidAsync("unregister", hotKeyEntry.Id);
         }, this._Logger);
         hotKeyEntry.Dispose();
@@ -841,6 +844,7 @@ public partial class HotKeysContext : IDisposable, IAsyncDisposable
             if (this._Disposed) return false;
 
             var context = await this._JSContextTask;
+            if (context is null) return true;
             this._Disposed = true;
             foreach (var entry in this._Keys)
             {

--- a/HotKeys2/HotKeysContext.cs
+++ b/HotKeys2/HotKeysContext.cs
@@ -844,7 +844,6 @@ public partial class HotKeysContext : IDisposable, IAsyncDisposable
             if (this._Disposed) return false;
 
             var context = await this._JSContextTask;
-            if (context is null) return true;
             this._Disposed = true;
             foreach (var entry in this._Keys)
             {
@@ -852,6 +851,7 @@ public partial class HotKeysContext : IDisposable, IAsyncDisposable
                 entry._NotifyStateChanged = null;
             }
             lock (this._Keys) this._Keys.Clear();
+            if (context is null) return true;
             await JS.InvokeSafeAsync(async () =>
             {
                 await context.InvokeVoidAsync("dispose");


### PR DESCRIPTION
## Problem

On Blazor Server, when a user navigates away or closes the browser tab, in-flight JS interop calls are cancelled. This produces `TaskCanceledException` (often double-wrapped in `AggregateException`) that gets logged as errors, e.g.:

```
Toolbelt.Blazor.HotKeys2.HotKeys[0] One or more errors occurred. (One or more errors occurred. (A task was canceled.))
System.AggregateException: One or more errors occurred. (One or more errors occurred. (A task was canceled.))
 ---> System.AggregateException: One or more errors occurred. (A task was canceled.)
 ---> System.Threading.Tasks.TaskCanceledException: A task was canceled.
    at Toolbelt.Blazor.HotKeys2.Extensions.JS.<>c.<ImportScriptAsync>b__2_0(Task`1 task)
    ...
    at Toolbelt.Blazor.HotKeys2.Extensions.JS.InvokeSafeAsync(Func`1 action, ILogger logger)
```

These errors are harmless but noisy and alarming in production logs.

## Root Cause

`JSDisconnectedException` is already silently swallowed in `JS.InvokeSafeAsync`, but `OperationCanceledException` / `TaskCanceledException` is not — even though it represents the same scenario (circuit gone). Additionally:

- `CreateJSContextAsync` calls `_Syncer.InvokeAsync` without a logger, so a cancelled task propagates as a faulted `_JSContextTask`.
- Callers of `_JSContextTask` then dereference a `null` `IJSObjectReference`, throwing `ArgumentNullException`, which is also logged.

## Fix

1. **`JS.InvokeSafeAsync`** — also silently swallow `OperationCanceledException` and `AggregateException` whose inner exceptions are all cancellations.
2. **`SemaphoreSlimExtensions.InvokeAsync`** — same, so that the no-logger path in `CreateJSContextAsync` returns `null` instead of faulting the task.
3. **`HotKeysContext`** — null-guard all four usages of `_JSContextTask` so that when the JS context was never created, dispose/register/update/unregister bail out cleanly.
